### PR TITLE
Updates manifest.json with current syntax

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -4,8 +4,10 @@
     ],
     "custom_middleware": {
         "driver": "python",
-        "auth_check": {
+        "auth_check": [
+            {
             "name": "MyAuthMiddleware"
-        }
+            }
+        ]
     }
 }


### PR DESCRIPTION
https://tyk.io/docs/customise-tyk/plugins/rich-plugins/plugin-bundles/ says that the `hook` must be an array.