### PR TITLE
Fix broken tutorial link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,4 +2,4 @@
 
 This repository provides a sample [Python](https://www.python.org/) plugin for [Tyk](https://tyk.io).
 
-This plugin implements a custom authentication middleware, check [our tutorial](https://tyk.io/docs/customise-tyk/plugins/rich-plugins/python/custom-auth-python-tutorial/) for more details.
+This plugin implements a custom authentication middleware, check [our tutorial](https://tyk.io/docs/plugins/rich-plugins/python/custom-auth-python-tutorial/) for more details.


### PR DESCRIPTION
The `customise-tyk` prefix seems to no longer be used, and thus simply removing it fixes the link.